### PR TITLE
build: add devdependency that is causing build to fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@koa/router": "^13.1.1",
         "@tazama-lf/frms-coe-lib": "5.1.0-rc.7",
         "@types/koa": "^2.15.0",
+        "@types/koa__router": "^12.0.4",
         "@types/koa-bodyparser": "^4.3.12",
         "axios": "^1.10.0",
         "koa": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@koa/router": "^13.1.1",
+    "@types/koa__router": "^12.0.4",
     "@tazama-lf/frms-coe-lib": "5.1.0-rc.7",
     "@types/koa": "^2.15.0",
     "@types/koa-bodyparser": "^4.3.12",


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
add devdependency that is causing build to fail [here](https://github.com/tazama-lf/nats-utilities/actions/runs/16652732334/job/47185193948)

## Why are we doing this?
To pass the build and have an rc image published

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
