### PR TITLE
build: frms-coe-lib version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@koa/router": "^13.1.1",
-    "@tazama-lf/frms-coe-lib": "6.0.0-rc.12",
+    "@tazama-lf/frms-coe-lib": "6.0.0-rc.13",
     "@types/koa": "^2.15.0",
     "@types/koa-bodyparser": "^4.3.12",
     "axios": "^1.12.2",


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
