### PR TITLE
fix: bump axios to ^1.18.1 for CVE remediation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "nats-utilities",
-  "version": "4.0.0-rc.1",
+  "version": "4.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nats-utilities",
-      "version": "4.0.0-rc.1",
+      "version": "4.0.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@koa/router": "^13.1.1",
         "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
         "@types/koa": "^2.15.0",
         "@types/koa-bodyparser": "^4.3.12",
-        "axios": "^1.12.2",
+        "axios": "^1.18.1",
         "koa": "^3.0.0",
         "koa-bodyparser": "^4.4.1",
         "nats": "^2.29.3",
@@ -2822,6 +2822,18 @@
       "integrity": "sha512-2zHEyuhSJOuCrmas9YV0YL/MFCWLxe1dS6k/ENhgYrb/JqyMnadLN4iIAc9kkZrbElMDyyAGH/0J18OPErOWLg==",
       "license": "MIT"
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -3182,13 +3194,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -6073,6 +6086,19 @@
       "license": "MIT",
       "dependencies": {
         "next-line": "^1.1.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@tazama-lf/frms-coe-lib": "8.2.0-rc.6",
     "@types/koa": "^2.15.0",
     "@types/koa-bodyparser": "^4.3.12",
-    "axios": "^1.12.2",
+    "axios": "^1.18.1",
     "koa": "^3.0.0",
     "koa-bodyparser": "^4.4.1",
     "nats": "^2.29.3",


### PR DESCRIPTION
# fix: bump axios to ^1.18.1 for CVE remediation

## Why

Part of the platform-wide axios remediation for the June 2026 advisory batch (CVE-2026-44486..44496 plus the June GHSA wave). `nats-utilities` declared a direct `axios ^1.12.2`, which resolved to a vulnerable version.

## What

- `package.json`: `axios ^1.12.2` -> `^1.18.1`
- `package-lock.json` regenerated; `npm ls axios` confirms `axios@1.18.1`

## Verification

- `npm run build` - clean
- `npm test` - 5/5 pass
- `npm run lint` - eslint clean (prettier line-ending warnings are the known local CRLF artefact; CI runs on Linux/LF)

## Regression watch (axios 1.18.x behaviour changes)

- Cross-origin redirects now strip caller-set auth/API-key headers
- Malformed `http:`/`https:` URLs (missing `//`) now throw `ERR_INVALID_URL`
- Merged config/header objects are null-prototype
- `AxiosError.toJSON()` now redacts sensitive keys (log output changes)
